### PR TITLE
Feat: public AZ 수에 따른 NAT Gateway 동적 구성 로직 개선

### DIFF
--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  az_set = toset([for s in var.public_subnets : s.az])
+  nat_azs      = toset([for s in values(var.public_subnets) : s.az])
+  nat_azs_list = tolist(local.nat_azs)
 }

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "public subnet ID 리스트"
+  value       = [for s in aws_subnet.public : s.id]
+}
+
+output "private_subnet_ids" {
+  description = "private subnet ID 리스트"
+  value       = [for s in aws_subnet.private : s.id]
+}
+
+output "db_subnet_ids" {
+  description = "DB subnet ID 리스트"
+  value       = [for k, s in aws_subnet.private : s.id if startswith(k, "db")]
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
public AZ 수에 따른 NAT Gateway 동적 구성 로직 개선
## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- AZ가 1개일 경우 NAT Gateway 1개만 생성 후 모든 private subnet에 연결
- AZ가 2개 이상일 경우 AZ별로 NAT Gateway 생성 및 해당 AZ의 subnet에 연결
- local.az_set → local.nat_azs로 명확한 분기 변수 구성
- private route table 및 association 로직도 조건 분기 처리

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
- #17
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->