### PR TITLE
Feat: Route53 모듈 생성 및 dev,prod 환경에 적용

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -27,3 +27,10 @@ module "network" {
   common_tags     = var.common_tags
   env             = var.env
 }
+
+module "route53" {
+  source = "../../modules/route53"
+  domain_zone_name = var.domain_zone_name
+  domains_alias = []
+  domains_records = []
+}

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -62,3 +62,9 @@ variable "env" {
   type        = string
   default     = "dev"
 }
+
+variable "domain_zone_name" {
+  description = "환경"
+  type        = string
+  default     = "dolpin.shop"
+}

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -27,3 +27,10 @@ module "network" {
   common_tags     = var.common_tags
   env             = var.env
 }
+
+module "route53" {
+  source = "../../modules/route53"
+  domain_zone_name = var.domain_zone_name
+  domains_alias = []
+  domains_records = []
+}

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -79,3 +79,9 @@ variable "env" {
   type        = string
   default     = "prod"
 }
+
+variable "domain_zone_name" {
+  description = "환경"
+  type        = string
+  default     = "dolpin.shop"
+}

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -1,0 +1,24 @@
+data "aws_route53_zone" "public" {
+  name = var.domain_zone_name
+}
+
+resource "aws_route53_record" "alias_record" {
+  for_each = var.domains_alias
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = each.value.domain_name
+  type    = "A"
+
+  alias {
+    name                   = each.value.alias_name
+    zone_id                = each.value.alias_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "alias_be_record" {
+  for_each = var.domains_records
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = each.value.domain_name
+  type    = "A"
+  records = each.value.records
+}

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -1,0 +1,20 @@
+variable "domain_zone_name" {
+  description = "서비스 도메인 zone 이름"
+  type        = string
+}
+
+variable "domains_alias" {
+  description = "도메인 별칭"
+  type = map(object({
+    domain_name   = string
+    alias_name    = string
+    alias_zone_id = string
+  }))
+}
+variable "domains_records" {
+  description = "도메인 레코드"
+  type = map(object({
+    domain_name = string
+    records     = list(string)
+  }))
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
Route53 A 레코드 및 Alias 레코드를 관리하는 Terraform 모듈을 생성하고, 이를 dev 및 prod 환경에 적용했습니다. 

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- Route53 모듈 생성 (`data`, `A record`, `Alias record`, 변수 구성 포함)
- dev, prod 환경에 Route53 모듈 적용
- `domain_zone_name` 기본값 설정 (dolpin.shop)
- `domains_alias`, `domains_records`는 구조만 정의하고 초기값은 빈 값으로 설정

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
- #14
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
- 현재는 도메인 레코드가 등록되지 않았으며, 추후 be,fe, s3 같은 서비스 도입시 작성 필요.