### PR TITLE
Feat: ALB 모듈 생성 및 shared,dev,prod 환경에 적용

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -20,10 +20,19 @@ provider "aws" {
 }
 
 module "network" {
-  source = "../../modules/network"
+  source          = "../../modules/network"
   vpc_cidr        = var.vpc_cidr
   public_subnets  = var.public_subnets
   private_subnets = var.private_subnets
   common_tags     = var.common_tags
   env             = var.env
+}
+
+module "loadbalancer" {
+  source            = "../../modules/loadbalancer"
+  vpc_id            = module.network.vpc_id
+  public_subnet_ids = module.network.public_subnet_ids
+  cert_arn          = ""
+  common_tags       = var.common_tags
+  env               = var.env
 }

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -27,3 +27,12 @@ module "network" {
   common_tags     = var.common_tags
   env             = var.env
 }
+
+module "loadbalancer" {
+  source            = "../../modules/loadbalancer"
+  vpc_id            = module.network.vpc_id
+  public_subnet_ids = module.network.public_subnet_ids
+  cert_arn          = ""
+  common_tags       = var.common_tags
+  env               = var.env
+}

--- a/envs/shared/main.tf
+++ b/envs/shared/main.tf
@@ -27,3 +27,12 @@ module "network" {
   common_tags     = var.common_tags
   env             = var.env
 }
+
+module "loadbalancer" {
+  source            = "../../modules/loadbalancer"
+  vpc_id            = module.network.vpc_id
+  public_subnet_ids = module.network.public_subnet_ids
+  cert_arn          = ""
+  common_tags       = var.common_tags
+  env               = var.env
+}

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -1,0 +1,80 @@
+resource "aws_security_group" "this" {
+  name        = "be-alb-sg-${var.env}"
+  description = "Allow HTTP and HTTPS inbound traffic"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "alb-sg-${var.env}"
+  })
+}
+
+resource "aws_lb" "this" {
+  name               = "be-alb-${var.env}"
+  load_balancer_type = "application"
+  subnets            = var.public_subnet_ids
+  security_groups    = [aws_security_group.this.id]
+
+  tags = merge(var.common_tags, {
+    Name = "alb-${var.env}"
+  })
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.cert_arn
+
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "No matching rule found"
+      status_code  = "404"
+    }
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "alb-listener-${var.env}"
+  })
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+  tags = merge(var.common_tags, {
+    Name = "alb-redirect-listener-${var.env}"
+  })
+}

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -1,0 +1,3 @@
+output "https_listener_arn" {
+  value = aws_lb_listener.https.arn
+}

--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -1,0 +1,24 @@
+variable "vpc_id" {
+  description = "vpc id"
+  type = string
+}
+
+variable "common_tags" {
+  description = "기본 태그"
+  type = map(string)
+}
+
+variable "env" {
+  description = "환경"
+  type = string
+}
+
+variable "public_subnet_ids" {
+  description = "ALB에 사용할 Subnet ID"
+  type        = list(string)
+}
+
+variable "cert_arn" {
+  description = "lb에서 사용할 인증서"
+  type = string
+}


### PR DESCRIPTION
## 📝 PR 개요  
HTTPS 리스너 및 리디렉션을 포함한 ALB 모듈을 생성하고, 이를 dev 환경에 적용했습니다. 초기 상태에서는 인증서 ARN을 비워두고 구조만 구성해두었습니다.

## 🔍 변경사항  
- ALB 보안 그룹, Application Load Balancer 리소스 정의
- HTTPS 리스너 및 HTTP → HTTPS 리디렉션 리스너 구성
- 공통 태그, 환경 변수 기반 리소스 이름 자동화
- Target Group은 각 서비스에서 별도 생성하도록 분리
- dev,prod,shared 환경에서 ALB 모듈 적용
- 인증서 ARN(`cert_arn`)은 초기에는 빈 값으로 설정

## 🔗 관련 이슈  
- #12   <!-- 이슈 번호가 있다면 기입 -->

## 🚨 주의사항  
- 현재 `cert_arn`은 빈 문자열로 설정되어 있어 실제 HTTPS 리스너는 작동하지 않음
- 서비스 단의 Target Group 리소스 생성 및 ALB 리스너 연결 필요
