### PR TITLE
Feat: ECR module 작성

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -27,3 +27,23 @@ module "network" {
   common_tags     = var.common_tags
   env             = var.env
 }
+
+module "ecr_backend" {
+  source = "../../modules/ecr"
+
+  env                     = var.env
+  name                    = var.be_ecr_name
+  image_tag_mutability    = var.image_tag_mutability
+  scan_on_push            = var.scan_on_push
+  encryption_type         = var.encryption_type
+}
+
+module "ecr_frontend" {
+  source = "../../modules/ecr"
+
+  env                     = var.env
+  name                    = var.fe_ecr_name
+  image_tag_mutability    = var.image_tag_mutability
+  scan_on_push            = var.scan_on_push
+  encryption_type         = var.encryption_type
+}

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -62,3 +62,34 @@ variable "env" {
   type        = string
   default     = "dev"
 }
+
+### ECR
+variable "be_ecr_name" {
+  description = "Backend ECR 리포지토리 이름"
+  type        = string
+  default     = "dolpin-backend"
+}
+
+variable "fe_ecr_name" {
+  description = "Frontend ECR 리포지토리 이름"
+  type        = string
+  default     = "dolpin-frontend"
+}
+
+variable "image_tag_mutability" {
+  description = "태그 변경 가능 여부"
+  type        = string
+  default     = "IMMUTABLE"
+}
+
+variable "scan_on_push" {
+  description = "푸시 시 이미지 자동 보안 스캔 여부"
+  type        = bool
+  default     = true
+}
+
+variable "encryption_type" {
+  description = "암호화 방식"
+  type        = string
+  default     = "AES256"
+}

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -27,3 +27,23 @@ module "network" {
   common_tags     = var.common_tags
   env             = var.env
 }
+
+module "ecr_backend" {
+  source = "../../modules/ecr"
+
+  env                     = var.env
+  name                    = var.be_ecr_name
+  image_tag_mutability    = var.image_tag_mutability
+  scan_on_push            = var.scan_on_push
+  encryption_type         = var.encryption_type
+}
+
+module "ecr_frontend" {
+  source = "../../modules/ecr"
+
+  env                     = var.env
+  name                    = var.fe_ecr_name
+  image_tag_mutability    = var.image_tag_mutability
+  scan_on_push            = var.scan_on_push
+  encryption_type         = var.encryption_type
+}

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -79,3 +79,34 @@ variable "env" {
   type        = string
   default     = "prod"
 }
+
+### ECR
+variable "be_ecr_name" {
+  description = "Backend ECR 리포지토리 이름"
+  type        = string
+  default     = "dolpin-backend"
+}
+
+variable "fe_ecr_name" {
+  description = "Frontend ECR 리포지토리 이름"
+  type        = string
+  default     = "dolpin-frontend"
+}
+
+variable "image_tag_mutability" {
+  description = "태그 변경 가능 여부"
+  type        = string
+  default     = "IMMUTABLE"
+}
+
+variable "scan_on_push" {
+  description = "푸시 시 이미지 자동 보안 스캔 여부"
+  type        = bool
+  default     = true
+}
+
+variable "encryption_type" {
+  description = "암호화 방식"
+  type        = string
+  default     = "AES256"
+}

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -21,3 +21,32 @@ resource "aws_ecr_repository" "this" {
     managedBy   = "terraform"
   })
 }
+
+resource "aws_ecr_repository_policy" "this" {
+  for_each = var.repository_policy != null && var.repository_policy != "" ? { default = var.repository_policy } : {}
+  repository = aws_ecr_repository.this.name
+  policy     = each.value
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each   = var.enable_lifecycle_policy ? { default = true } : {}
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      for rule in var.lifecycle_policy_rules : {
+        rulePriority = rule.rulePriority
+        description  = rule.description
+        selection = {
+          tagStatus   = rule.tagStatus
+          countType   = rule.countType
+          countUnit   = rule.countUnit
+          countNumber = rule.countNumber
+        }
+        action = {
+          type = rule.action_type
+        }
+      }
+    ]
+  })
+}

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "this" {
-  name                 = var.name
+  name                 = "${var.name}-${var.env}"
   image_tag_mutability = var.image_tag_mutability
 
   image_scanning_configuration {

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,23 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = var.image_tag_mutability
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
+  dynamic "encryption_configuration" {
+    for_each = var.encryption_type != null ? [var.encryption_type] : []
+    content {
+      encryption_type = encryption_configuration.value
+      kms_key         = encryption_configuration.value == "KMS" ? var.kms_key : null
+    }
+  }
+
+  tags = merge(var.common_tags, {
+    Name        = var.name
+    environment = var.env
+    component   = "ecr"
+    managedBy   = "terraform"
+  })
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_url" {
+  description = "ECR 리포지토리 URL"
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "arn" {
+  description = "ECR 리포지토리 ARN"
+  value       = aws_ecr_repository.this.arn
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -36,6 +36,42 @@ variable "kms_key" {
   default     = null
 }
 
+variable "repository_policy" {
+  description = "ECR 리포지토리에 적용할 IAM 정책(JSON 문자열)"
+  type    = string
+  default = null
+}
+
+variable "enable_lifecycle_policy" {
+  description = "라이프사이클 정책 활성화 여부"
+  type        = bool
+  default     = true
+}
+
+variable "lifecycle_policy_rules" {
+  description = "ECR 라이프사이클 정책 정의 목록"
+  type = list(object({
+    rulePriority = number
+    description  = string
+    tagStatus    = string
+    countType    = string
+    countUnit    = string
+    countNumber  = number
+    action_type  = string
+  }))
+  default = [
+    {
+      rulePriority = 1
+      description  = "Expire untagged images after 10 days"
+      tagStatus    = "untagged"
+      countType    = "sinceImagePushed"
+      countUnit    = "days"
+      countNumber  = 10
+      action_type  = "expire"
+    }
+  ]
+}
+
 variable "common_tags" {
   description = "기본 태그"
   type        = map(string)

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,43 @@
+variable "env" {
+  description = "배포 환경 (예: dev, prod)"
+  type        = string
+}
+
+variable "name" {
+  description = "ECR 리포지토리 이름"
+  type        = string
+}
+
+variable "image_tag_mutability" {
+  description = "태그 변경 가능 여부"
+  type        = string
+  default     = "IMMUTABLE"
+}
+
+variable "scan_on_push" {
+  description = "푸시 시 이미지 자동 보안 스캔 여부"
+  type        = bool
+  default     = true
+}
+
+variable "encryption_type" {
+  description = "암호화 방식 (AES256 또는 KMS)"
+  type        = string
+  default     = "AES256"
+  validation {
+    condition     = contains(["AES256", "KMS"], var.encryption_type)
+    error_message = "encryption_type은 'AES256' 또는 'KMS'여야 합니다."
+  }
+}
+
+variable "kms_key" {
+  description = "KMS 암호화 시 사용할 KMS Key ARN (encryption_type이 KMS일 경우 필수)"
+  type        = string
+  default     = null
+}
+
+variable "common_tags" {
+  description = "기본 태그"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
AWS ECR(Elastic Container Registry) Repository 생성을 위한 재사용 가능한 Terraform 모듈을 추가했습니다.
보안 설정(KMS 또는 AES256), 태그 불변성, 이미지 스캔, IAM 정책, 라이프사이클 정책까지 설정 가능합니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- ECR Repository 생성
  - 리포지토리 이름은 ${var.name}-${var.env} 형식으로 지정
  - IMMUTABLE 또는 MUTABLE 태그 불변성 설정 지원
  - 이미지 푸시 시 자동 스캔(scan_on_push) 옵션 적용
  - 암호화 설정: AES256 또는 KMS 방식 지원 (선택적으로 KMS Key ARN 입력 가능)
- Repository 정책
  - 외부에서 repository_policy(JSON 문자열)를 넘겨주는 경우 IAM 정책 적용
- life cycle 정책
  - enable_lifecycle_policy = true일 때 정책 활성화
  - lifecycle_policy_rules 목록을 통해 유연한 정책 구성 가능

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
#5 

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
- encryption_type이 KMS일 경우, kms_key 변수에 KMS Key ARN을 반드시 지정해야 함
- repository_policy는 유효한 JSON 문자열 형태여야 하며, 형식 오류 시 Terraform 에러 발생