### PR TITLE
Fix: 도메인 이름 및 Route53 변수 타입 수정

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -40,8 +40,8 @@ module "loadbalancer" {
 module "route53" {
   source = "../../modules/route53"
   domain_zone_name = var.domain_zone_name
-  domains_alias = []
-  domains_records = []
+  domains_alias = {}
+  domains_records = {}
 }
 
 module "rds" {

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -71,7 +71,7 @@ variable "env" {
 variable "domain_zone_name" {
   description = "환경"
   type        = string
-  default     = "dolpin.shop"
+  default     = "dolpin.site"
 }
 
 variable "db_engine" {

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -40,8 +40,8 @@ module "loadbalancer" {
 module "route53" {
   source = "../../modules/route53"
   domain_zone_name = var.domain_zone_name
-  domains_alias = []
-  domains_records = []
+  domains_alias = {}
+  domains_records = {}
 }
 
 module "rds" {

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -84,7 +84,7 @@ variable "env" {
 variable "domain_zone_name" {
   description = "환경"
   type        = string
-  default     = "dolpin.shop"
+  default     = "dolpin.site"
 }
 
 variable "db_engine" {

--- a/envs/shared/main.tf
+++ b/envs/shared/main.tf
@@ -40,6 +40,6 @@ module "loadbalancer" {
 module "route53" {
   source = "../../modules/route53"
   domain_zone_name = var.domain_zone_name
-  domains_alias = []
-  domains_records = []
+  domains_alias = {}
+  domains_records = {}
 }

--- a/envs/shared/variables.tf
+++ b/envs/shared/variables.tf
@@ -61,5 +61,5 @@ variable "env" {
 variable "domain_zone_name" {
   description = "환경"
   type        = string
-  default     = "dolpin.shop"
+  default     = "dolpin.site"
 }


### PR DESCRIPTION
## 📝 PR 개요  
도메인 설정 관련 오류를 수정하고, `alias` 및 `records` 변수의 타입을 올바르게 변경했습니다.

## 🔍 변경사항  
- domain_zone_name 값을 `dolpin.shop` → `dolpin.site`로 수정
- `domains_alias`와 `domains_records` 변수를 빈 리스트(`[]`)에서 빈 맵(`{}`)으로 변경하여 타입 불일치 오류 해결

## 🔗 관련 이슈  
Closes #23

## 🚨 주의사항  
