### PR TITLE
Feat: VPC Peering module 작성 

### DIFF
--- a/envs/dev/.terraform.lock.hcl
+++ b/envs/dev/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.99.1"
   constraints = "5.99.1"
   hashes = [
+    "h1:atjIGE0AtiuzUl6VF8ttGpVdQ583uBslxmIn0A/egyA=",
     "h1:xgPyZArCfKVMy8sThzhb0IernbFy0fJGm897ztejZAQ=",
     "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
     "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",

--- a/envs/dev/data.tf
+++ b/envs/dev/data.tf
@@ -1,0 +1,8 @@
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket = "dolpin-terraform-state-bn2gz7v3he1rj0ia"
+    key    = "shared/terraform/terraform.tfstate"
+    region = "ap-northeast-2"
+  }
+}

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -14,6 +14,7 @@ terraform {
     use_lockfile = true
   }
 }
+
 # AWS Provider
 provider "aws" {
   region = var.aws_region
@@ -26,4 +27,17 @@ module "network" {
   private_subnets = var.private_subnets
   common_tags     = var.common_tags
   env             = var.env
+}
+
+module "shared_to_dev_peering" {
+  source = "../../modules/vpc_peering"
+
+  env                        = var.env
+  component                  = "shared-to-dev"
+  requester_vpc_id           = data.terraform_remote_state.shared.outputs.vpc_id
+  accepter_vpc_id            = module.network.vpc_id
+  requester_vpc_cidr         = data.terraform_remote_state.shared.outputs.vpc_cidr
+  accepter_vpc_cidr          = var.vpc_cidr
+  requester_route_table_ids  = data.terraform_remote_state.shared.outputs.private_route_table_ids
+  accepter_route_table_ids   = module.network.private_route_table_ids
 }

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -38,6 +38,10 @@ module "shared_to_dev_peering" {
   accepter_vpc_id            = module.network.vpc_id
   requester_vpc_cidr         = data.terraform_remote_state.shared.outputs.vpc_cidr
   accepter_vpc_cidr          = var.vpc_cidr
-  requester_route_table_ids  = data.terraform_remote_state.shared.outputs.private_route_table_ids
-  accepter_route_table_ids   = module.network.private_route_table_ids
+  requester_route_table_ids = {
+    default = data.terraform_remote_state.shared.outputs.private_route_table_ids["ap-northeast-2a"]
+  }
+  accepter_route_table_ids = {
+    default = module.network.private_route_table_ids["ap-northeast-2a"]
+  }
 }

--- a/envs/prod/.terraform.lock.hcl
+++ b/envs/prod/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.99.1"
   constraints = "5.99.1"
   hashes = [
+    "h1:atjIGE0AtiuzUl6VF8ttGpVdQ583uBslxmIn0A/egyA=",
     "h1:xgPyZArCfKVMy8sThzhb0IernbFy0fJGm897ztejZAQ=",
     "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
     "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",

--- a/envs/prod/data.tf
+++ b/envs/prod/data.tf
@@ -1,0 +1,8 @@
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket = "dolpin-terraform-state-bn2gz7v3he1rj0ia"
+    key    = "shared/terraform/terraform.tfstate"
+    region = "ap-northeast-2"
+  }
+}

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -27,3 +27,16 @@ module "network" {
   common_tags     = var.common_tags
   env             = var.env
 }
+
+module "shared_to_prod_peering" {
+  source = "../../modules/vpc_peering"
+
+  env                        = var.env
+  component                  = "shared-to-prod"
+  requester_vpc_id           = data.terraform_remote_state.shared.outputs.vpc_id
+  accepter_vpc_id            = module.network.vpc_id
+  requester_vpc_cidr         = data.terraform_remote_state.shared.outputs.vpc_cidr
+  accepter_vpc_cidr          = var.vpc_cidr
+  requester_route_table_ids  = data.terraform_remote_state.shared.outputs.private_route_table_ids
+  accepter_route_table_ids   = module.network.private_route_table_ids
+}

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -37,6 +37,11 @@ module "shared_to_prod_peering" {
   accepter_vpc_id            = module.network.vpc_id
   requester_vpc_cidr         = data.terraform_remote_state.shared.outputs.vpc_cidr
   accepter_vpc_cidr          = var.vpc_cidr
-  requester_route_table_ids  = data.terraform_remote_state.shared.outputs.private_route_table_ids
-  accepter_route_table_ids   = module.network.private_route_table_ids
+  requester_route_table_ids = {
+    "ap-northeast-2a" = data.terraform_remote_state.shared.outputs.private_route_table_ids["ap-northeast-2a"]
+  }
+  accepter_route_table_ids = {
+    "ap-northeast-2a" = module.network.private_route_table_ids["ap-northeast-2a"]
+    "ap-northeast-2c" = module.network.private_route_table_ids["ap-northeast-2c"]
+  }
 }

--- a/envs/shared/.terraform.lock.hcl
+++ b/envs/shared/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.99.1"
   constraints = "5.99.1"
   hashes = [
+    "h1:atjIGE0AtiuzUl6VF8ttGpVdQ583uBslxmIn0A/egyA=",
     "h1:xgPyZArCfKVMy8sThzhb0IernbFy0fJGm897ztejZAQ=",
     "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
     "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",

--- a/envs/shared/outputs.tf
+++ b/envs/shared/outputs.tf
@@ -1,11 +1,11 @@
 output "vpc_id" {
-  value = aws_vpc.this.id
+  value = module.network.vpc_id
 }
 
 output "vpc_cidr" {
-  value = var.vpc_cidr
+  value = module.network.vpc_cidr
 }
 
 output "private_route_table_ids" {
-  value = values(aws_route_table.private)[*].id
+  value = module.network.private_route_table_ids
 }

--- a/envs/shared/outputs.tf
+++ b/envs/shared/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  value = var.vpc_cidr
+}
+
+output "private_route_table_ids" {
+  value = values(aws_route_table.private)[*].id
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -3,6 +3,11 @@ output "vpc_id" {
   value = aws_vpc.this.id
 }
 
+output "vpc_cidr" {
+  description = "VPC CIDR 블록"
+  value       = var.vpc_cidr
+}
+
 output "public_subnet_ids" {
   description = "public subnet ID 리스트"
   value       = [for s in aws_subnet.public : s.id]
@@ -19,5 +24,8 @@ output "db_subnet_ids" {
 }
 
 output "private_route_table_ids" {
-  value = values(aws_route_table.private)[*].id
+  description = "AZ별 private route table ID"
+  value = {
+    for az, rt in aws_route_table.private : az => rt.id
+  }
 }

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -17,3 +17,7 @@ output "db_subnet_ids" {
   description = "DB subnet ID 리스트"
   value       = [for k, s in aws_subnet.private : s.id if startswith(k, "db")]
 }
+
+output "private_route_table_ids" {
+  value = values(aws_route_table.private)[*].id
+}

--- a/modules/vpc_peering/main.tf
+++ b/modules/vpc_peering/main.tf
@@ -1,0 +1,41 @@
+# requester_vpc_id에서 accepter_vpc_id로 VPC Peering 요청을 보내며, 같은 계정+리전이므로 auto_accept = true로 설정해 자동 수락 처리함.
+resource "aws_vpc_peering_connection" "this" {
+  vpc_id        = var.requester_vpc_id
+  peer_vpc_id   = var.accepter_vpc_id
+  auto_accept   = var.auto_accept
+
+  # 두 VPC 간에 서로의 프라이빗 DNS 레코드를 DNS 이름으로 조회 가능하도록 설정함.
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  tags = {
+    Name        = "${var.component}-peer"
+    component   = var.component
+    type        = "vpc-peering"
+    environment = var.env
+    managed_by  = "terraform"
+  }
+}
+
+# 요청자 VPC의 라우팅 테이블에 수락자 VPC의 CIDR로 가는 트래픽은 해당 VPC 피어링 연결로 전송하라는 라우팅 경로를 설정
+resource "aws_route" "requester_to_accepter" {
+  for_each = toset(compact(var.requester_route_table_ids))
+
+  route_table_id            = each.value
+  destination_cidr_block    = var.accepter_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.this.id
+}
+
+# 수락자 VPC의 라우팅 테이블에도 요청자 VPC로 향하는 경로를 설정함
+resource "aws_route" "accepter_to_requester" {
+  for_each = toset(compact(var.accepter_route_table_ids))
+
+  route_table_id            = each.value
+  destination_cidr_block    = var.requester_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.this.id
+}

--- a/modules/vpc_peering/main.tf
+++ b/modules/vpc_peering/main.tf
@@ -24,7 +24,7 @@ resource "aws_vpc_peering_connection" "this" {
 
 # 요청자 VPC의 라우팅 테이블에 수락자 VPC의 CIDR로 가는 트래픽은 해당 VPC 피어링 연결로 전송하라는 라우팅 경로를 설정
 resource "aws_route" "requester_to_accepter" {
-  for_each = toset(compact(var.requester_route_table_ids))
+  for_each = var.requester_route_table_ids
 
   route_table_id            = each.value
   destination_cidr_block    = var.accepter_vpc_cidr
@@ -33,7 +33,7 @@ resource "aws_route" "requester_to_accepter" {
 
 # 수락자 VPC의 라우팅 테이블에도 요청자 VPC로 향하는 경로를 설정함
 resource "aws_route" "accepter_to_requester" {
-  for_each = toset(compact(var.accepter_route_table_ids))
+  for_each = var.accepter_route_table_ids
 
   route_table_id            = each.value
   destination_cidr_block    = var.requester_vpc_cidr

--- a/modules/vpc_peering/variables.tf
+++ b/modules/vpc_peering/variables.tf
@@ -1,0 +1,45 @@
+variable "env" {
+  description = "대상 vpc 이름 (예: dev, prod)"
+  type        = string
+}
+
+variable "component" {
+  description = "논리적 peering 명 (예: shared-to-dev)"
+  type        = string
+}
+
+variable "requester_vpc_id" {
+  description = "Peering 요청 VPC ID"
+  type        = string
+}
+
+variable "accepter_vpc_id" {
+  description = "Peering 수락 VPC ID"
+  type        = string
+}
+
+variable "requester_vpc_cidr" {
+  description = "요청 VPC의 CIDR 블록"
+  type        = string
+}
+
+variable "accepter_vpc_cidr" {
+  description = "수락 VPC의 CIDR 블록"
+  type        = string
+}
+
+variable "auto_accept" {
+  description = "같은 계정/리전이면 true, cross-account면 false"
+  type        = bool
+  default     = true
+}
+
+variable "requester_route_table_ids" {
+  description = "shared VPC의 route table id 목록 (cicd, monitoring 등)"
+  type        = list(string)
+}
+
+variable "accepter_route_table_ids" {
+  description = "dev 또는 prod VPC의 route table id 목록 (fe, be, db 등)"
+  type        = list(string)
+}

--- a/modules/vpc_peering/variables.tf
+++ b/modules/vpc_peering/variables.tf
@@ -36,10 +36,10 @@ variable "auto_accept" {
 
 variable "requester_route_table_ids" {
   description = "shared VPC의 route table id 목록 (cicd, monitoring 등)"
-  type        = list(string)
+  type        = map(string)
 }
 
 variable "accepter_route_table_ids" {
   description = "dev 또는 prod VPC의 route table id 목록 (fe, be, db 등)"
-  type        = list(string)
+  type        = map(string)
 }


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
AWS 환경에서 공유 VPC(shared)와 서비스 VPC(dev, prod) 간의 통신을 가능하게 하기 위해 VPC Peering 모듈을 작성하고, 각 환경 간 연결 구성을 적용했습니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- vpc peering module 작성
  - 요청자 vpc <-> 수락자 vpc 라우팅 설정
  - 요청자/수락자 모두 allow_remote_vpc_dns_resolution = true 설정 
- shared <-> dev
  - 라우팅 테이블 : ap-northeast-2a 기준 단일 구성
- shared <-> prod
  - 라우팅 테이블 : ap-northeast-2a, 2c 구성  

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
#3

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
- requester_route_table_ids, accepter_route_table_ids는 AZ를 키로 가지는 map(string) 형태여야 하며, 각 AZ에 맞게 라우팅 테이블이 존재해야 함
- Cross-account Peering의 경우 auto_accept = false로 설정 후 수동 수락 필요
- VPC Peering 후에도 보안 그룹 설정이 양방향으로 허용되어야 통신 가능