### PR TITLE
Feat : NAT Gateway AZ 지정 방식 변경을 위한 nat_azs 변수 도입

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -27,6 +27,7 @@ module "network" {
   private_subnets = var.private_subnets
   common_tags     = var.common_tags
   env             = var.env
+  nat_azs = var.nat_azs
 }
 
 module "shared_to_dev_peering" {

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -18,9 +18,14 @@ variable "public_subnets" {
     map_public_ip_on_launch = bool
   }))
   default = {
-    tool = {
+    tool-a = {
       cidr                    = "10.20.1.0/24"
       az                      = "ap-northeast-2a"
+      map_public_ip_on_launch = true
+    }
+    tool-c = {
+      cidr                    = "10.20.2.0/24"
+      az                      = "ap-northeast-2c"
       map_public_ip_on_launch = true
     }
   }
@@ -33,13 +38,21 @@ variable "private_subnets" {
     az   = string
   }))
   default = {
-    fe = {
+    fe-a = {
       cidr = "10.20.10.0/24"
       az   = "ap-northeast-2a"
     }
-    be = {
+    fe-c = {
+      cidr = "10.20.20.0/24"
+      az   = "ap-northeast-2c"
+    }
+    be-a = {
       cidr = "10.20.110.0/24"
       az   = "ap-northeast-2a"
+    }
+    be-c = {
+      cidr = "10.20.120.0/24"
+      az   = "ap-northeast-2c"
     }
     db-a = {
       cidr = "10.20.210.0/24"
@@ -126,4 +139,9 @@ variable "db_multi_az" {
   description = "db가 multi az 지원 여부"
   type = bool
   default = false
+}
+variable "nat_azs" {
+  description = "NAT Gateway를 배치할 AZ 목록"
+  type        = list(string)
+  default     = ["ap-northeast-2a"]
 }

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -27,6 +27,7 @@ module "network" {
   private_subnets = var.private_subnets
   common_tags     = var.common_tags
   env             = var.env
+  nat_azs         = var.nat_azs
 }
 
 module "shared_to_prod_peering" {

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -140,3 +140,9 @@ variable "db_multi_az" {
   type = bool
   default = true
 }
+
+variable "nat_azs" {
+  description = "NAT Gateway를 배치할 AZ 목록"
+  type        = list(string)
+  default     = ["ap-northeast-2a", "ap-northeast-2c"]
+}

--- a/envs/shared/main.tf
+++ b/envs/shared/main.tf
@@ -26,6 +26,7 @@ module "network" {
   private_subnets = var.private_subnets
   common_tags     = var.common_tags
   env             = var.env
+  nat_azs         = var.nat_azs
 }
 
 module "loadbalancer" {

--- a/envs/shared/variables.tf
+++ b/envs/shared/variables.tf
@@ -63,3 +63,9 @@ variable "domain_zone_name" {
   type        = string
   default     = "dolpin.site"
 }
+
+variable "nat_azs" {
+  description = "NAT Gateway를 배치할 AZ 목록"
+  type        = list(string)
+  default     = ["ap-northeast-2a"]
+}

--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  nat_azs      = toset([for s in values(var.public_subnets) : s.az])
+  nat_azs      = toset(var.nat_azs)
   nat_azs_list = tolist(local.nat_azs)
 }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -71,6 +71,7 @@ resource "aws_route_table_association" "public" {
 # NAT Gateway Elastic IP
 resource "aws_eip" "nat_eip" {
   for_each = local.nat_azs
+  
   tags = merge(var.common_tags, {
     Name = "nat-eip-${each.key}-${var.env}"
   })
@@ -79,10 +80,11 @@ resource "aws_eip" "nat_eip" {
 resource "aws_nat_gateway" "this" {
   for_each      = local.nat_azs
   allocation_id = aws_eip.nat_eip[each.key].id
-  # Place NAT Gateway in the public subnet for this AZ
-  subnet_id = lookup({ for s in aws_subnet.public : s.availability_zone => s.id }, each.key)
+  subnet_id     = lookup({ for k, s in aws_subnet.public : s.availability_zone => s.id }, each.key)
 
-  tags = merge(var.common_tags, { Name = "nat-${each.key}-${var.env}" })
+  tags = merge(var.common_tags, {
+    Name = "nat-${each.key}-${var.env}"
+  })
 }
 
 # Private Route Table (NAT Gateway 연결)

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -29,3 +29,8 @@ variable "env" {
   description = "환경"
   type = string
 }
+
+variable "nat_azs" {
+  description = "NAT Gateway를 배치할 AZ 목록"
+  type        = list(string)
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
기존에는 public_subnets 변수로부터 NAT Gateway의 AZ를 자동으로 추출했지만,
ALB는 서로 다른 AZ에 최소 2개의 서브넷이 필요하므로, NAT Gateway 또한 이에 맞춰 배치할 AZ를 명시적으로 지정할 수 있도록 수정하였습니다.
## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- ALB 요구사항에 따라 NAT Gateway를 배치할 AZ를 명시적으로 지정
- 기존 public_subnets에서 추출하던 방식에서 nat_azs 변수로 구조 변경
- nat_azs 변수 추가 및 관련 로컬 변수, for_each 로직 수정 

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
- #26
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->