### PR TITLE
Refactor: accepter VPC 라우팅 테이블 전체를 VPC Peering에 반영

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -42,9 +42,7 @@ module "shared_to_dev_peering" {
   requester_route_table_ids = {
     default = data.terraform_remote_state.shared.outputs.private_route_table_ids["ap-northeast-2a"]
   }
-  accepter_route_table_ids = {
-    default = module.network.private_route_table_ids["ap-northeast-2a"]
-  }
+  accepter_route_table_ids  = module.network.private_route_table_ids
 }
 
 module "ecr_backend" {

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -42,10 +42,7 @@ module "shared_to_prod_peering" {
   requester_route_table_ids = {
     "ap-northeast-2a" = data.terraform_remote_state.shared.outputs.private_route_table_ids["ap-northeast-2a"]
   }
-  accepter_route_table_ids = {
-    "ap-northeast-2a" = module.network.private_route_table_ids["ap-northeast-2a"]
-    "ap-northeast-2c" = module.network.private_route_table_ids["ap-northeast-2c"]
-  }
+  accepter_route_table_ids  = module.network.private_route_table_ids
 }
     
 module "ecr_backend" {


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
VPC Peering 모듈 사용 시 accepter_route_table_ids 전달 방식을 간결화하고, 고가용성 확보를 위한 AZ 확장 대응을 개선합니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- accepter_route_table_ids 전달 방식 단순화
  - 기존: AZ별로 "ap-northeast-2a", "ap-northeast-2c"를 개별 지정
  - 변경: module.network.private_route_table_ids 전체를 그대로 전달

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
#31
 
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->