### PR TITLE
Feat: S3 + CDN module 작성

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -77,7 +77,13 @@ module "loadbalancer" {
 module "route53" {
   source = "../../modules/route53"
   domain_zone_name = var.domain_zone_name
-  domains_alias = {}
+  domains_alias = {
+    cdn = {
+      domain_name   = var.cdn_domain_name
+      alias_name    = module.loadbalancer.alb_dns_name
+      alias_zone_id = module.loadbalancer.alb_zone_id
+    }
+  }
   domains_records = {}
 }
 
@@ -105,7 +111,6 @@ module "acm_seoul" {
   subject_alternative_names = [var.domain_wildcard]
 }
 
-
 module "acm_nova" {
   providers                 = { aws = aws.nova }
   source                    = "../../modules/acm"
@@ -114,4 +119,14 @@ module "acm_nova" {
   domain_zone_name          = var.domain_zone_name
   domain_name               = var.domain_name
   subject_alternative_names = [var.domain_wildcard]
+}
+
+module "s3" {
+  source = "../../modules/s3"
+  env                  = var.env
+  bucket_name          = var.bucket_name
+  domain_name          = var.cdn_domain_name
+  acm_certificate_arn  = module.acm_nova.cert_arn
+  common_tags          = var.common_tags
+  cors_origins         = var.cors_origins
 }

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -80,8 +80,8 @@ module "route53" {
   domains_alias = {
     cdn = {
       domain_name   = var.cdn_domain_name
-      alias_name    = module.loadbalancer.alb_dns_name
-      alias_zone_id = module.loadbalancer.alb_zone_id
+      alias_name    = module.s3.cloudfront_domain_name
+      alias_zone_id = module.s3.cloudfront_zone_id
     }
   }
   domains_records = {}

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -122,11 +122,13 @@ variable "domain_name" {
   type        = string
   default     = "dev.dolpin.site"
 }
+
 variable "domain_wildcard" {
   description = "도메인 인증서 와일드 카드"
   type        = string
   default     = "*.dev.dolpin.site"
 }
+
 variable "db_engine" {
   description = "database engine 종류 (ex: mysql, postgres 등)"
   type = string
@@ -150,8 +152,28 @@ variable "db_multi_az" {
   type = bool
   default = false
 }
+
 variable "nat_azs" {
   description = "NAT Gateway를 배치할 AZ 목록"
   type        = list(string)
   default     = ["ap-northeast-2a"]
+}
+
+### s3
+variable "bucket_name" {
+  description = "S3 버킷 이름"
+  type        = string
+  default     = "s3-dolpin-image-dev"
+}
+
+variable "cdn_domain_name" {
+  description = "CloudFront용 도메인"
+  type        = string
+  default     = "cdn.dev.dolpin.site"
+}
+
+variable "cors_origins" {
+  description = "CORS 허용 origin 리스트"
+  type        = list(string)
+  default     = ["https://fe.dev.dolpin.site"]
 }

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -77,7 +77,13 @@ module "loadbalancer" {
 module "route53" {
   source = "../../modules/route53"
   domain_zone_name = var.domain_zone_name
-  domains_alias = {}
+  domains_alias = {
+    cdn = {
+      domain_name   = var.cdn_domain_name
+      alias_name    = module.loadbalancer.alb_dns_name
+      alias_zone_id = module.loadbalancer.alb_zone_id
+    }
+  }
   domains_records = {}
 }
 
@@ -105,7 +111,6 @@ module "acm_seoul" {
   subject_alternative_names = [var.domain_wildcard]
 }
 
-
 module "acm_nova" {
   providers                 = { aws = aws.nova }
   source                    = "../../modules/acm"
@@ -114,4 +119,14 @@ module "acm_nova" {
   domain_zone_name          = var.domain_zone_name
   domain_name               = var.domain_name
   subject_alternative_names = [var.domain_wildcard]
+}
+
+module "s3" {
+  source = "../../modules/s3"
+  env                  = var.env
+  bucket_name          = var.bucket_name
+  domain_name          = var.cdn_domain_name
+  acm_certificate_arn  = module.acm_nova.cert_arn
+  common_tags          = var.common_tags
+  cors_origins         = var.cors_origins
 }

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -80,8 +80,8 @@ module "route53" {
   domains_alias = {
     cdn = {
       domain_name   = var.cdn_domain_name
-      alias_name    = module.loadbalancer.alb_dns_name
-      alias_zone_id = module.loadbalancer.alb_zone_id
+      alias_name    = module.s3.cloudfront_domain_name
+      alias_zone_id = module.s3.cloudfront_zone_id
     }
   }
   domains_records = {}

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -158,3 +158,22 @@ variable "nat_azs" {
   type        = list(string)
   default     = ["ap-northeast-2a", "ap-northeast-2c"]
 }
+
+### s3
+variable "bucket_name" {
+  description = "S3 버킷 이름"
+  type        = string
+  default     = "s3-dolpin-image-prod"
+}
+
+variable "cdn_domain_name" {
+  description = "CloudFront에 연결할 도메인"
+  type        = string
+  default     = "cdn.dolpin.site"
+}
+
+variable "cors_origins" {
+  description = "CORS 허용 origin 리스트"
+  type        = list(string)
+  default     = ["https://dolpin.site"]
+}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -114,3 +114,46 @@ resource "aws_cloudfront_distribution" "this" {
     Name = "cdn-${var.bucket_name}"
   })
 }
+
+resource "aws_cloudfront_cache_policy" "image_cdn_cache" {
+  name = "image-cdn-cache-${var.env}"
+
+  default_ttl = 3600  
+  max_ttl     = 86400 
+  min_ttl     = 0      
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {  
+      cookie_behavior = "none"
+    }
+
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = ["Origin"]
+      }
+    }
+
+    query_strings_config { 
+      query_string_behavior = "none"
+    }
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "cors" {
+  name = "cors-policy-${var.env}"
+
+  cors_config {
+    access_control_allow_credentials = false
+    access_control_allow_headers {
+      items = ["*"]
+    }
+    access_control_allow_methods {
+      items = ["GET", "HEAD", "OPTIONS"]
+    }
+    access_control_allow_origins {
+      items = var.cors_origins
+    }
+    origin_override = true
+  }
+}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,0 +1,61 @@
+# 이미지 파일 저장할 S3 bucket 생성
+resource "aws_s3_bucket" "this" {
+  bucket        = var.bucket_name
+  force_destroy = true 
+
+  tags = merge(var.common_tags, {
+    Name = var.bucket_name
+  })
+}
+
+# 외부 주체가 객체를 업로드하더라도 버킷 소유자가 해당 객체의 소유자가 되도록 설정
+resource "aws_s3_bucket_ownership_controls" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred" 
+  }
+}
+
+# S3 퍼블릭 접근을 방지
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+# CORS 설정
+resource "aws_s3_bucket_cors_configuration" "cors" {
+  bucket = aws_s3_bucket.this.id
+
+  cors_rule {
+    allowed_methods = ["GET", "HEAD", "PUT", "POST"]
+    allowed_origins = var.cors_origins
+    allowed_headers = ["*"]
+    expose_headers  = ["ETag", "x-amz-request-id"]
+    max_age_seconds = 3600
+  }
+}
+
+# 객체 버전 관리 설정
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# 객체 저장 시 자동으로 암호화 수행
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -157,3 +157,32 @@ resource "aws_cloudfront_response_headers_policy" "cors" {
     origin_override = true
   }
 }
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket_policy" "allow_cf" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.allow_cf.json
+}
+
+# S3와 CloudFront 연결 위한 리소스
+data "aws_iam_policy_document" "allow_cf" {
+  statement {
+    sid     = "AllowCloudFrontOAC"
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = ["arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${aws_cloudfront_distribution.this.id}"]
+    }
+  }
+}

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_domain_name" {
+  description = "CloudFront 배포 도메인 이름"
+  value       = aws_cloudfront_distribution.this.domain_name
+}
+
+output "cloudfront_zone_id" {
+  description = "CloudFront 고정 호스팅존 ID"
+  value       = "Z2FDTNDATAQYW2"
+}

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -8,6 +8,16 @@ variable "bucket_name" {
   type        = string
 }
 
+variable "domain_name" {
+  description = "CloudFront 도메인 (Route 53 또는 외부 도메인)"
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "CloudFront에서 사용할 ACM 인증서 ARN (us-east-1 리전)"
+  type        = string
+}
+
 variable "common_tags" {
   description = "기본 태그"
   type        = map(string)

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -1,0 +1,21 @@
+variable "env" {
+  description = "대상 vpc 이름 (예: dev, prod)"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "S3 버킷 이름 (고유해야 함)"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "기본 태그"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cors_origins" {
+  description = "CORS 허용 origin 리스트"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
정적 이미지 리소스를 제공하기 위한 S3 + CloudFront 인프라 구성을 추가하고, Route53 alias 도메인을 통해 접근할 수 있도록 설정을 개선하였습니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- S3 구성
  - 버킷 생성 및 리소스 강제 삭제(force_destroy) 설정
  - 객체 업로드 시 버킷 소유자 소유 설정 (OwnershipControls)
  - 퍼블릭 접근 완전 차단 (Public Access Block 4종)
  - 객체 버전 관리 활성화
  - 서버 측 암호화 설정(AES256)
  - CORS 허용 정책 설정 (GET, HEAD, PUT, POST)
  - S3에 CloudFront가 안전하게 접근할 수 있도록 OAC 연동 + bucket policy 설정
- CloudFront 구성
  - S3 Regional Domain을 오리진으로 사용
  - OAC 방식(origin_access_control_id)으로 S3와 연동
  - viewer protocol 정책 redirect-to-https, 메서드 제한(GET/HEAD)
  - cache policy, CORS response headers 정책 구성
  - ACM 인증서를 통한 HTTPS 지원
  - alias 도메인 설정을 통해 사용자 지정 도메인 지원

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
#7 

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->