### PR TITLE
Feat : 비용 보고 자동화 모듈 및 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+*.zip

--- a/envs/static/.terraform.lock.hcl
+++ b/envs/static/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.99.1"
   constraints = "5.99.1"

--- a/envs/static/main.tf
+++ b/envs/static/main.tf
@@ -26,3 +26,11 @@ module "acm_validation" {
   domain_name               = "boamoa.shop"
   subject_alternative_names = ["*.boamoa.shop", "*.dev.boamoa.shop"]
 }
+
+module "cost_report" {
+  source                   = "./modules/cost_report"
+  schedule_expression_cron = "cron(0 9 * * ? *)"
+  common_tags              = var.common_tags
+  env                      = var.env
+  component                = "cr"
+}

--- a/envs/static/modules/cost_report/data.tf
+++ b/envs/static/modules/cost_report/data.tf
@@ -3,3 +3,11 @@ data "archive_file" "lambda" {
   source_file = "${path.module}/files/lambda_function.py"
   output_path = "lambda_function_payload.zip"
 }
+
+data "aws_iam_policy" "cost_usage_report_automation_policy" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSCostAndUsageReportAutomationPolicy"
+}
+
+data "aws_iam_policy" "lambda_basic_execution_role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/envs/static/modules/cost_report/data.tf
+++ b/envs/static/modules/cost_report/data.tf
@@ -1,0 +1,5 @@
+data "archive_file" "lambda" {
+  type        = "zip"
+  source_file = "${path.module}/files/lambda_function.py"
+  output_path = "lambda_function_payload.zip"
+}

--- a/envs/static/modules/cost_report/files/lambda_function.py
+++ b/envs/static/modules/cost_report/files/lambda_function.py
@@ -1,0 +1,93 @@
+import boto3
+import json
+import datetime
+import urllib.request
+
+# AWS 클라이언트 생성
+secrets_client = boto3.client('secretsmanager')
+ce = boto3.client('ce')
+
+# Secrets Manager에서 Discord Webhook URL 가져오기
+def get_webhook_url():
+    try:
+        response = secrets_client.get_secret_value(SecretId="discord/webhook")
+        secret_dict = json.loads(response['SecretString'])
+        return secret_dict['url']
+    except Exception as e:
+        print(f"❌ Secrets Manager에서 Webhook URL 조회 실패: {e}")
+        raise
+
+# Discord로 Embed 메시지 전송
+def send_embed_to_discord(period_label, cost, now, start, webhook_url, monthly_cost=None):
+    fields = [
+        {"name": "📅 기준일", "value": f"{start}", "inline": True},
+    ]
+
+    try:
+        formatted_cost = f"${float(cost):,.2f}"
+    except ValueError:
+        formatted_cost = str(cost)
+
+    fields.append({"name": "💵 비용", "value": formatted_cost, "inline": True})
+
+    if monthly_cost is not None:
+        try:
+            formatted_monthly_cost = f"${float(monthly_cost):,.2f}"
+        except ValueError:
+            formatted_monthly_cost = str(monthly_cost)
+
+        fields.append({"name": "📊 이번 달 총 지출", "value": formatted_monthly_cost, "inline": False})
+
+    embed = {
+        "title": f"AWS 비용 보고서",
+        "fields": fields
+    }
+
+    payload = {
+        "username": "AWS Cost Report",
+        "embeds": [embed]
+    }
+
+    try:
+        req = urllib.request.Request(
+            webhook_url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json", "User-Agent": "MyLambdaBot/1.0"}
+        )
+        with urllib.request.urlopen(req) as res:
+            print(f"✅ Discord 응답 코드: {res.status}")
+    except Exception as e:
+        print(f"❌ Discord 전송 실패: {e}")
+
+# Lambda 핸들러 함수
+def lambda_handler(event, context):
+    print("📥 받은 이벤트:", json.dumps(event))
+    now = datetime.datetime.utcnow()
+    webhook_url = get_webhook_url()
+
+    start = (now - datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+    end = now.strftime('%Y-%m-%d')
+    label = "어제 하루"
+
+    try:
+        daily_cost_data = ce.get_cost_and_usage(
+            TimePeriod={'Start': start, 'End': end},
+            Granularity='DAILY',
+            Metrics=['UnblendedCost']
+        )
+        daily_amount = daily_cost_data['ResultsByTime'][0]['Total']['UnblendedCost']['Amount']
+
+        # 이번 달 누적 비용 조회
+        start_of_month = now.replace(day=1).strftime('%Y-%m-%d')
+        monthly_cost_data = ce.get_cost_and_usage(
+            TimePeriod={'Start': start_of_month, 'End': end},
+            Granularity='MONTHLY',
+            Metrics=['UnblendedCost']
+        )
+        monthly_amount = monthly_cost_data['ResultsByTime'][0]['Total']['UnblendedCost']['Amount']
+
+        send_embed_to_discord(label, daily_amount, now, start, webhook_url, monthly_amount)
+
+    except Exception as e:
+        print(f"❌ 비용 조회 실패: {str(e)}")
+        send_embed_to_discord("조회 실패", "N/A", now, start, webhook_url)

--- a/envs/static/modules/cost_report/main.tf
+++ b/envs/static/modules/cost_report/main.tf
@@ -1,0 +1,94 @@
+# IAM 정책 (비용 조회, 시크릿 조회)
+resource "aws_iam_policy" "lambda_cost_explorer_read_policy" {
+  name = "LambdaCostExplorerReadAccess"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ce:GetCostAndUsage",
+          "ce:GetCostForecast",
+          "ce:GetDimensionValues"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = merge(var.common_tags, {
+    Name = "${var.component}-ce-pol-${var.env}"
+  })
+}
+
+resource "aws_iam_policy" "lambda_secret_read_policy" {
+  name = "LambdaSecretReadAccess"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ],
+        Resource = "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:discord/webhook-3JLYiI"
+      }
+    ]
+  })
+  tags = merge(var.common_tags, {
+    Name = "${var.component}-sec-pol-${var.env}"
+  })
+}
+
+# Lambda용 IAM 역할
+resource "aws_iam_role" "lambda_cost_explorer_role" {
+  name = "lambda-cost-explorer-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+  tags = merge(var.common_tags, {
+    Name = "${var.component}-lbd-role-${var.env}"
+  })
+}
+
+# Lambda 역할에 정책 연결
+resource "aws_iam_role_policy_attachment" "attach_cost_explorer_read_policy" {
+  role       = aws_iam_role.lambda_cost_explorer_role.name
+  policy_arn = aws_iam_policy.lambda_cost_explorer_read_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "attach_secret_read_policy" {
+  role       = aws_iam_role.lambda_cost_explorer_role.name
+  policy_arn = aws_iam_policy.lambda_secret_read_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "attach_cost_usage_report_policy" {
+  role       = aws_iam_role.lambda_cost_explorer_role.name
+  policy_arn = data.aws_iam_policy.cost_usage_report_automation_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "attach_lambda_basic_execution" {
+  role       = aws_iam_role.lambda_cost_explorer_role.name
+  policy_arn = data.aws_iam_policy.lambda_basic_execution_role.arn
+}
+
+# Lambda 함수 정의
+resource "aws_lambda_function" "cost_report_lambda" {
+  filename         = data.archive_file.lambda.output_path
+  function_name    = "cost-report-lambda"
+  role             = aws_iam_role.lambda_cost_explorer_role.arn
+  source_code_hash = data.archive_file.lambda.output_base64sha256
+
+  handler = "lambda_function.lambda_handler"
+  runtime = "python3.13"
+  tags = merge(var.common_tags, {
+    Name = "${var.component}-lbd-${var.env}"
+  })
+}

--- a/envs/static/modules/cost_report/variables.tf
+++ b/envs/static/modules/cost_report/variables.tf
@@ -1,3 +1,8 @@
+variable "schedule_expression_cron" {
+  description = "스케줄러 cron 식"
+  type = string
+}
+
 variable "common_tags" {
   description = "모든 리소스에 적용할 공통 태그"
   type        = map(string)

--- a/envs/static/modules/cost_report/variables.tf
+++ b/envs/static/modules/cost_report/variables.tf
@@ -1,0 +1,14 @@
+variable "common_tags" {
+  description = "모든 리소스에 적용할 공통 태그"
+  type        = map(string)
+}
+
+variable "env" {
+  description = "환경"
+  type        = string
+}
+
+variable "component" {
+  description = "컴포넌트 이름"
+  type        = string
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
AWS 비용 보고 자동화를 위해 cost_report 모듈을 추가하고, Lambda 함수 및 스케줄러 설정을 구현합니다.
이를 통해 매일 오전 9시(Asia/Seoul)에 Cost Explorer 데이터를 조회하여 Discord로 전송할 수 있습니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- 매일 오전 09:00(Asia/Seoul)에 비용 조회 및 Discord 전송 자동화
- cost_report Terraform 모듈 생성 및 환경(main.tf) 호출 설정
- lambda_function.py에 Cost Explorer 호출 로직 및 Embed 전송 구현
- 비용 조회, Secrets Manager 접근용 IAM 정책·역할 구성
- EventBridge Scheduler 스케줄 설정 및 호출 역할 추가
## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
- #36 
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
- Secrets Manager에 "discord/webhook" Secret이 정확히 생성되어 있어야 합니다.