### PR TITLE
Fix: 월초 비용 조회 시 replace 에러 수정

### DIFF
--- a/envs/static/modules/cost_report/files/lambda_function.py
+++ b/envs/static/modules/cost_report/files/lambda_function.py
@@ -78,7 +78,8 @@ def lambda_handler(event, context):
         daily_amount = daily_cost_data['ResultsByTime'][0]['Total']['UnblendedCost']['Amount']
 
         # 이번 달 누적 비용 조회
-        start_of_month = now.replace(day=1).strftime('%Y-%m-%d')
+        yesterday = now - datetime.timedelta(days=1)
+        start_of_month = yesterday.replace(day=1).strftime('%Y-%m-%d')
         monthly_cost_data = ce.get_cost_and_usage(
             TimePeriod={'Start': start_of_month, 'End': end},
             Granularity='MONTHLY',


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
월초 실행 시 비용 조회 Lambda에서 replace 에러 및 조회 기간 오류가 발생해 수정한다.
## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- 전날 기준 datetime 객체에서 replace 호출하도록 변경
- 월초(1일)에도 정상 동작하도록 start_of_month 계산 방식 수정

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
 #42
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->