### PR TITLE
Feat: ASG 인스턴스 Draining 전환 문제 해결

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -131,6 +131,7 @@ module "fe" {
   max_size                     = var.fe_max_size
   request_per_target_threshold = var.fe_request_per_target_threshold
   health_check_path            = var.fe_health_check_path
+  health_check_period          = var.fe_health_check_period 
   allowed_cidrs                = var.fe_allowed_cidrs
   enable_blue_green            = var.enable_blue_green
   additional_policy_arns       = var.fe_additional_policy_arns
@@ -157,6 +158,7 @@ module "be" {
   max_size                 = var.be_max_size
   target_cpu_utilization   = var.be_target_cpu_utilization
   health_check_path        = var.be_health_check_path
+  health_check_period      = var.be_health_check_period 
   allowed_cidrs            = var.be_allowed_cidrs
   enable_blue_green        = var.enable_blue_green
   additional_policy_arns   = var.be_additional_policy_arns

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -226,6 +226,12 @@ variable "fe_health_check_path" {
   default     = "/api/health"
 }
 
+variable "fe_health_check_period" {
+  description = "헬스 체크 대기 시간"
+  type        = number
+  default     = 600
+}
+
 variable "fe_allowed_cidrs" {
   description = "FE 인스턴스로의 접근을 허용할 CIDR 리스트"
   type        = list(string)
@@ -305,6 +311,12 @@ variable "be_health_check_path" {
   description = "BE ALB 헬스 체크 경로"
   type        = string
   default     = "/api/v1/health"
+}
+
+variable "be_health_check_period" {
+  description = "헬스 체크 대기 시간"
+  type        = number
+  default     = 300
 }
 
 variable "be_allowed_cidrs" {

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -131,6 +131,7 @@ module "fe" {
   max_size                     = var.fe_max_size
   request_per_target_threshold = var.fe_request_per_target_threshold
   health_check_path            = var.fe_health_check_path
+  health_check_period          = var.fe_health_check_period 
   allowed_cidrs                = var.fe_allowed_cidrs
   enable_blue_green            = var.enable_blue_green
   additional_policy_arns       = var.fe_additional_policy_arns
@@ -157,6 +158,7 @@ module "be" {
   max_size                 = var.be_max_size
   target_cpu_utilization   = var.be_target_cpu_utilization
   health_check_path        = var.be_health_check_path
+  health_check_period      = var.be_health_check_period 
   allowed_cidrs            = var.be_allowed_cidrs
   enable_blue_green        = var.enable_blue_green
   additional_policy_arns   = var.be_additional_policy_arns

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -226,6 +226,12 @@ variable "fe_health_check_path" {
   default     = "/api/health"
 }
 
+variable "fe_health_check_period" {
+  description = "헬스 체크 대기 시간"
+  type        = number
+  default     = 600
+}
+
 variable "fe_allowed_cidrs" {
   description = "FE 인스턴스로의 접근을 허용할 CIDR 리스트"
   type        = list(string)
@@ -305,6 +311,12 @@ variable "be_health_check_path" {
   description = "BE ALB 헬스 체크 경로"
   type        = string
   default     = "/api/v1/health"
+}
+
+variable "be_health_check_period" {
+  description = "헬스 체크 대기 시간"
+  type        = number
+  default     = 300
 }
 
 variable "be_allowed_cidrs" {

--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -94,13 +94,16 @@ resource "aws_lb_target_group" "blue" {
   protocol = "HTTP"
   vpc_id   = var.vpc_id
 
+  deregistration_delay = 60
+  slow_start           = 30
+
   health_check {
     path                = var.health_check_path
     matcher             = "200-399"
     interval            = 30
     timeout             = 5
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
   }
 
   target_type = "instance"
@@ -117,13 +120,16 @@ resource "aws_lb_target_group" "green" {
   protocol = "HTTP"
   vpc_id   = var.vpc_id
 
+  deregistration_delay = 60
+  slow_start           = 30
+
   health_check {
     path                = var.health_check_path
     matcher             = "200-399"
     interval            = 30
     timeout             = 5
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
   }
 
   target_type = "instance"
@@ -184,8 +190,8 @@ resource "aws_autoscaling_group" "this" {
     aws_lb_target_group.blue.arn
   ]
   health_check_type         = "ELB"
-  health_check_grace_period = 100
-  default_instance_warmup   = 60
+  health_check_grace_period = var.health_check_period
+  default_instance_warmup   = null
 
   lifecycle {
     create_before_destroy = true

--- a/modules/asg/variables.tf
+++ b/modules/asg/variables.tf
@@ -60,6 +60,11 @@ variable "health_check_path" {
   type        = string
 }
 
+variable "health_check_period" {
+  description = "헬스 체크 대기 시간"
+  type        = number
+}
+
 variable "alb_listener_arn_https" {
   description = "HTTPS Listener ARN"
   type        = string


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
Auto Scaling Group에서 생성된 EC2 인스턴스가 계속 unhealthy인 문제를 해결하기 위하여, Auto Scaling Group의 설정값들을 조정하였습니다. CodeDeploy의 ValidateService 단계에서 헬스체크를 수행하도록 하였습니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- Auto Scaling Group에 health_check_grace_period 값 조절
- ALB Target Group의 unhealthy_threshold 값 조정하여 일시적 응답 지연 허용

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
#40 

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->