### PR TITLE
Feat: Redis module 작성

### DIFF
--- a/envs/dev/.terraform.lock.hcl
+++ b/envs/dev/.terraform.lock.hcl
@@ -24,3 +24,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -226,3 +226,19 @@ module "codedeploy_backend" {
   enable_blue_green        = var.enable_blue_green
   common_tags              = var.common_tags
 }
+
+module "redis" {
+  source = "../../modules/redis"
+  vpc_id                   = module.network.vpc_id
+  redis_subnet_ids         = module.network.redis_subnet_ids 
+  allowed_cidrs            = []             
+  allow_sg_list            = [module.be.security_group_id]      
+  redis_prefix             = var.redis_prefix
+  redis_engine_version     = var.redis_engine_version
+  node_type                = var.node_type
+  cache_clusters           = var.cache_clusters
+  parameter_group_name     = var.parameter_group_name
+  snapshot_retention_limit = var.snapshot_retention_limit
+  env                      = var.env
+  common_tags              = var.common_tags
+}

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -63,11 +63,11 @@ variable "private_subnets" {
       az   = "ap-northeast-2c"
     }
     redis-a = {
-      cidr = "10.20.310.0/24"
+      cidr = "10.20.230.0/24"
       az   = "ap-northeast-2a"
     }
     redis-c = {
-      cidr = "10.20.320.0/24"
+      cidr = "10.20.240.0/24"
       az   = "ap-northeast-2c"
     }
   }
@@ -345,7 +345,8 @@ variable "be_secret_arns" {
   default     = [
     "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:dev/backend/env-*",
     "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:dev/rds/credentials/secret-*",
-    "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:codedeploy/discord/webhook-*"
+    "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:codedeploy/discord/webhook-*",
+    "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:dev/redis/credentials/secret-*"
   ]
 }
 
@@ -396,7 +397,7 @@ variable "redis_prefix" {
 variable "redis_engine_version" {
   description = "Redis 엔진 버전"
   type        = string
-  default     = "7.2"
+  default     = "7.0"
 }
 
 variable "node_type" {

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -62,6 +62,14 @@ variable "private_subnets" {
       cidr = "10.20.220.0/24"
       az   = "ap-northeast-2c"
     }
+    redis-a = {
+      cidr = "10.20.310.0/24"
+      az   = "ap-northeast-2a"
+    }
+    redis-c = {
+      cidr = "10.20.320.0/24"
+      az   = "ap-northeast-2c"
+    }
   }
 }
 

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -385,3 +385,40 @@ variable "deployment_config_name" {
   type        = string
   default     = "CodeDeployDefault.AllAtOnce"
 }
+
+# Redis
+variable "redis_prefix" {
+  description = "Redis group 이름 prefix"
+  type        = string
+  default     = "refresh-token-rg"
+}
+
+variable "redis_engine_version" {
+  description = "Redis 엔진 버전"
+  type        = string
+  default     = "7.2"
+}
+
+variable "node_type" {
+  description = "Redis 인스턴스 노드 타입"
+  type        = string
+  default     = "cache.t3.micro"
+}
+
+variable "cache_clusters" {
+  description = "Redis 클러스터의 캐시 노드 수 (primary + replica 개수)"
+  type        = number
+  default     = 1
+}
+
+variable "parameter_group_name" {
+  description = "Redis 파라미터 그룹 이름"
+  type        = string
+  default     = "default.redis7"
+}
+
+variable "snapshot_retention_limit" {
+  description = "유지할 snapshot 개수"
+  type        = number
+  default     = 0
+}

--- a/envs/prod/.terraform.lock.hcl
+++ b/envs/prod/.terraform.lock.hcl
@@ -24,3 +24,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -226,3 +226,19 @@ module "codedeploy_backend" {
   enable_blue_green        = var.enable_blue_green
   common_tags              = var.common_tags
 }
+
+module "redis" {
+  source = "../../modules/redis"
+  vpc_id                   = module.network.vpc_id
+  redis_subnet_ids         = module.network.redis_subnet_ids 
+  allowed_cidrs            = []             
+  allow_sg_list            = [module.be.security_group_id]      
+  redis_prefix             = var.redis_prefix
+  redis_engine_version     = var.redis_engine_version
+  node_type                = var.node_type
+  cache_clusters           = var.cache_clusters
+  parameter_group_name     = var.parameter_group_name
+  snapshot_retention_limit = var.snapshot_retention_limit
+  env                      = var.env
+  common_tags              = var.common_tags
+}

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -62,6 +62,14 @@ variable "private_subnets" {
       cidr = "10.10.220.0/24"
       az   = "ap-northeast-2c"
     },
+    redis-a = {
+      cidr = "10.10.310.0/24"
+      az   = "ap-northeast-2a"
+    },
+    redis-b = {
+      cidr = "10.10.320.0/24"
+      az   = "ap-northeast-2c"
+    }
   }
 }
 

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -385,3 +385,40 @@ variable "deployment_config_name" {
   type        = string
   default     = "CodeDeployDefault.AllAtOnce"
 }
+
+# Redis
+variable "redis_prefix" {
+  description = "Redis group 이름 prefix"
+  type        = string
+  default     = "refresh-token-rg"
+}
+
+variable "redis_engine_version" {
+  description = "Redis 엔진 버전"
+  type        = string
+  default     = "7.2"
+}
+
+variable "node_type" {
+  description = "Redis 인스턴스 노드 타입"
+  type        = string
+  default     = "cache.t3.micro"
+}
+
+variable "cache_clusters" {
+  description = "Redis 클러스터의 캐시 노드 수 (primary + replica 개수)"
+  type        = number
+  default     = 1
+}
+
+variable "parameter_group_name" {
+  description = "Redis 파라미터 그룹 이름"
+  type        = string
+  default     = "default.redis7"
+}
+
+variable "snapshot_retention_limit" {
+  description = "유지할 snapshot 개수"
+  type        = number
+  default     = 1
+}

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -63,11 +63,11 @@ variable "private_subnets" {
       az   = "ap-northeast-2c"
     },
     redis-a = {
-      cidr = "10.10.310.0/24"
+      cidr = "10.10.230.0/24"
       az   = "ap-northeast-2a"
     },
     redis-b = {
-      cidr = "10.10.320.0/24"
+      cidr = "10.10.240.0/24"
       az   = "ap-northeast-2c"
     }
   }
@@ -345,7 +345,8 @@ variable "be_secret_arns" {
   default     = [
     "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:prod/backend/env-*",
     "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:prod/rds/credentials/secret-*",
-    "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:codedeploy/discord/webhook-*"
+    "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:codedeploy/discord/webhook-*",
+    "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:prod/redis/credentials/secret-*"
   ]
 }
 
@@ -396,7 +397,7 @@ variable "redis_prefix" {
 variable "redis_engine_version" {
   description = "Redis 엔진 버전"
   type        = string
-  default     = "7.2"
+  default     = "7.0"
 }
 
 variable "node_type" {

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -25,6 +25,11 @@ output "db_subnet_ids" {
   value       = [for k, s in aws_subnet.private : s.id if startswith(k, "db")]
 }
 
+output "redis_subnet_ids" {
+  description = "Redis subnet ID 리스트"
+  value       = [for k, s in aws_subnet.private : s.id if startswith(k, "redis")]
+}
+
 output "private_route_table_ids" {
   description = "AZ별 private route table ID"
   value = {

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -64,14 +64,14 @@ resource "random_password" "redis_password" {
 }
 
 resource "aws_elasticache_replication_group" "this" { 
-  replication_group_id       = "refresh-token-rg-${var.env}"
+  replication_group_id       = "${var.redis_prefix}-${var.env}"
   description                = "refresh token 저장할 Redis"
   engine                     = "redis"
-  engine_version             = "7.2"
-  node_type                  = "cache.t3.micro"
-  num_cache_clusters         = 1
+  engine_version             = var.redis_engine_version
+  node_type                  = var.node_type 
+  num_cache_clusters         = var.cache_clusters
   port                       = 6379
-  parameter_group_name       = "default.redis7"
+  parameter_group_name       = var.parameter_group_name
   subnet_group_name          = aws_elasticache_subnet_group.this.name
   security_group_ids         = [aws_security_group.this.id]
   user_group_ids             = [aws_elasticache_user_group.this.user_group_id]

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,0 +1,32 @@
+resource "aws_elasticache_subnet_group" "this" { 
+  name        = "redis-subnet-group-${var.env}"
+  subnet_ids  = var.redis_subnet_ids
+
+  tags = merge(var.common_tags, {
+    Name = "redis-subnet-group-${var.env}"
+  })
+}
+
+resource "aws_security_group" "this" {
+  name        = "redis-sg-${var.env}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    cidr_blocks     = var.allowed_cidrs
+    security_groups = var.allow_sg_list
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "redis-sg-${var.env}"
+  })
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -102,7 +102,7 @@ resource "aws_elasticache_replication_group" "this" {
 }
 
 resource "aws_secretsmanager_secret" "redis_credentials" {
-  name = "${var.env}/re"
+  name = "${var.env}/redis/credentials/secret"
   tags = var.common_tags
 }
 

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -18,6 +18,11 @@ variable "allow_sg_list" {
   type = list(string)
 }
 
+variable "snapshot_retention_limit" {
+  description = "유지할 snapshot 개수"
+  type        = number
+}
+
 variable "env" {
   description = "환경"
   type        = string

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -1,0 +1,29 @@
+variable "vpc_id" {
+  description = "Redis VPC ID"
+  type        = string
+}
+
+variable "redis_subnet_ids" {
+  description = "Redis에 사용할 프라이빗 서브넷 ID 리스트"
+  type        = list(string)
+}
+
+variable "allowed_cidrs" {
+  description = "Redis 접근 허용 CIDR 리스트"
+  type        = list(string)
+}
+
+variable "allow_sg_list" {
+  description = "Redis 접근 허용 sg-id 리스트"
+  type = list(string)
+}
+
+variable "env" {
+  description = "환경"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "기본 태그"
+  type = map(string)
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -18,6 +18,31 @@ variable "allow_sg_list" {
   type = list(string)
 }
 
+variable "redis_prefix" {
+  description = "Redis group 이름 prefix"
+  type        = string
+}
+
+variable "redis_engine_version" {
+  description = "Redis 엔진 버전"
+  type        = string
+}
+
+variable "node_type" {
+  description = "Redis 인스턴스 노드 타입"
+  type        = string
+}
+
+variable "cache_clusters" {
+  description = "Redis 클러스터의 캐시 노드 수 (primary + replica 개수)"
+  type        = number
+}
+
+variable "parameter_group_name" {
+  description = "Redis 파라미터 그룹 이름"
+  type        = string
+}
+
 variable "snapshot_retention_limit" {
   description = "유지할 snapshot 개수"
   type        = number


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
ElastiCache Redis 클러스터 위한 인프라 구성 모듈을 생성했습니다. 

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- Redis 전용 Subnet Group 생성
- Redis 접근 제어용 Security Group 생성
- Redis 사용자 기본 계정 및 관리 계정 생성
- Redis User Group 구성 및 사용자 연결
- 비밀번호 자동 생성 및 Redis 접근 정보를 Secrets Manager에 저장
- Redis Replication Group 구성

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
#39 

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
- dev 환경은 자동 snapshot을 생성하지 않고, prod 환경은 하루 한 번 자동 snapshot을 생성하고, 가장 최근 1개만 유지되도록 설정하였습니다. snapshot 비용은 1GB당 0.085 USD라고 합니다.   