### PR TITLE
Feat: rds 보안그룹에 모니터링 CIDR 허용 설정 추가

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -104,7 +104,7 @@ module "rds" {
   common_tags           = var.common_tags
   env                   = var.env
   allow_sg_list         = [module.be.security_group_id]
-  allow_cidr_block_list = []
+  allow_cidr_block_list = [var.monitoring_cidr]
   db_engine             = var.db_engine
   db_engine_version     = var.db_engine_version
   db_instance_class     = var.db_instance_class

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -439,3 +439,9 @@ variable "snapshot_retention_limit" {
   type        = number
   default     = 0
 }
+
+variable "monitoring_cidr" {
+  description = "모니터링 인스턴스의 cidr"
+  type = string
+  default = "10.30.110.0/24"
+}

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -104,7 +104,7 @@ module "rds" {
   common_tags           = var.common_tags
   env                   = var.env
   allow_sg_list         = [module.be.security_group_id]
-  allow_cidr_block_list = []
+  allow_cidr_block_list = [var.monitoring_cidr]
   db_engine             = var.db_engine
   db_engine_version     = var.db_engine_version
   db_instance_class     = var.db_instance_class

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -439,3 +439,9 @@ variable "snapshot_retention_limit" {
   type        = number
   default     = 1
 }
+
+variable "monitoring_cidr" {
+  description = "모니터링 인스턴스의 cidr"
+  type = string
+  default = "10.30.110.0/24"
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
db 모니터링 보안 그룹을 설정한다.
## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- allow_cidr_block_list에 monitoring_cidr 변수를 기본값과 함께 추가
- 모니터링 인스턴스(10.30.110.0/24)에서 접근 가능하도록 구성
- dev, prod 환경 적용

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
 #53
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->