### PR TITLE
Fix: 비용알림 Rate limit exceeded 수정

### DIFF
--- a/envs/static/main.tf
+++ b/envs/static/main.tf
@@ -29,7 +29,7 @@ module "acm_validation" {
 
 module "cost_report" {
   source                   = "./modules/cost_report"
-  schedule_expression_cron = "cron(0 9 * * ? *)"
+  schedule_expression_cron = "cron(5 9 * * ? *)"
   common_tags              = var.common_tags
   env                      = var.env
   component                = "cr"

--- a/envs/static/modules/cost_report/main.tf
+++ b/envs/static/modules/cost_report/main.tf
@@ -88,6 +88,7 @@ resource "aws_lambda_function" "cost_report_lambda" {
 
   handler = "lambda_function.lambda_handler"
   runtime = "python3.13"
+  timeout = "60"
   tags = merge(var.common_tags, {
     Name = "${var.component}-lbd-${var.env}"
   })


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
매일 아침 오전 9시에 실행되는 비용 조회 람다를 수정한다. 에러는 아래와 같다
```
❌ 비용 조회 실패: An error occurred (LimitExceededException) when calling the GetCostAndUsage operation: Rate limit exceeded
```

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- 보고서 시간 9시 5분으로 변경
- 재시도 적용 (5번)
- 요청간 대기 시간 적용
- lambda timeout 60초 적용

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
 #55
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->