### PR TITLE
Feat: ASG 스케일 조정 및 EC2 제어 기능 Lambda에 통합 및 권한 추가

### DIFF
--- a/envs/static/main.tf
+++ b/envs/static/main.tf
@@ -41,4 +41,5 @@ module "tf_automation" {
   env              = var.env
   component        = "ta"
   lambda_schedules = var.lambda_schedules
+  asg_config = var.asg_config
 }

--- a/envs/static/modules/tf_automation/data.tf
+++ b/envs/static/modules/tf_automation/data.tf
@@ -3,3 +3,7 @@ data "archive_file" "lambda" {
   source_file = "${path.module}/files/lambda_function.py"
   output_path = "lambda_function_payload.zip"
 }
+
+data "aws_iam_policy" "lambda_basic_execution_role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/envs/static/modules/tf_automation/files/lambda_function.py
+++ b/envs/static/modules/tf_automation/files/lambda_function.py
@@ -82,9 +82,9 @@ def scale_asg(
     try:
         asg_client.update_auto_scaling_group(
             AutoScalingGroupName=name,
-            MinSize=int(os.getenv("ASG_MIN", min_size)),
-            DesiredCapacity=int(os.getenv("ASG_DESIRED", desire_size)),
-            MaxSize=int(os.getenv("ASG_MAX", max_size)),
+            MinSize=int(min_size),
+            DesiredCapacity=int(desire_size),
+            MaxSize=int( max_size),
         )
         print(f"ASG {name} {action} 성공")
         return True
@@ -191,12 +191,12 @@ def lambda_handler(event, context):
     min_size = event.get("min_size")
     desire_size = event.get("desire_size")
     max_size = event.get("max_size")
-    
+
     if action not in ("start", "stop") or not env:
         print(f"Invalid invocation. action={action}, Environment={env}")
         return
 
-    region = os.environ.get("AWS_REGION", "ap-northeast-2")
+    region = "ap-northeast-2"
     results: List[Dict[str, str]] = []
 
     webhook_url = get_webhook_url()

--- a/envs/static/modules/tf_automation/locals.tf
+++ b/envs/static/modules/tf_automation/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  lambda_schedules = {
+    for k, v in var.lambda_schedules : k => merge(
+      v,
+      v.action == "stop" ? {
+        min_size     = 0
+        desired_size = 0
+        max_size     = 0
+      } : var.asg_config[v.env]
+    )
+  }
+}

--- a/envs/static/modules/tf_automation/main.tf
+++ b/envs/static/modules/tf_automation/main.tf
@@ -93,7 +93,7 @@ resource "aws_iam_role_policy" "scheduler_lambda_invoke_policy" {
 
 # 스케줄러 설정 
 resource "aws_scheduler_schedule" "tf_automation_scheduler" {
-  for_each = var.lambda_schedules
+  for_each = local.lambda_schedules
 
   name = "tf_${each.key}"
   
@@ -110,6 +110,9 @@ resource "aws_scheduler_schedule" "tf_automation_scheduler" {
     input = jsonencode({
       action = each.value.action
       env    = each.value.env
+      min_size = each.value.min_size
+      desired_size = each.value.desired_size
+      max_size = each.value.max_size
     })
   }
 }

--- a/envs/static/modules/tf_automation/main.tf
+++ b/envs/static/modules/tf_automation/main.tf
@@ -11,7 +11,12 @@ resource "aws_iam_policy" "lambda_tf_automation_policy" {
           "ec2:DescribeInstances", 
           "rds:StartDBInstance",
           "rds:StopDBInstance",
-          "rds:DescribeDBInstances"
+          "rds:DescribeDBInstances",
+          "rds:ListTagsForResource",
+          "autoscaling:DescribeTags",
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:UpdateAutoScalingGroup"
         ],
         "Resource" : "*"
       }
@@ -22,8 +27,27 @@ resource "aws_iam_policy" "lambda_tf_automation_policy" {
   })
 }
 
+resource "aws_iam_policy" "lambda_secret_read_policy" {
+  name = "${var.component}-LambdaSecretReadAccess-${var.env}"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ],
+        Resource = "arn:aws:secretsmanager:ap-northeast-2:794038223418:secret:discord/webhook-3JLYiI"
+      }
+    ]
+  })
+  tags = merge(var.common_tags, {
+    Name = "${var.component}-sec-pol-${var.env}"
+  })
+}
+
 resource "aws_iam_role" "lambda_tf_automation_role" {
-  name = "lambda-tf-automation-role"
+  name = "lambdaTfAutomationRole"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -41,9 +65,20 @@ resource "aws_iam_role" "lambda_tf_automation_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "attach_tf_automation_policy" {
-  role       = aws_iam_role.lambda_tf_automation_role.arn
+  role       = aws_iam_role.lambda_tf_automation_role.name
   policy_arn = aws_iam_policy.lambda_tf_automation_policy.arn
 }
+
+resource "aws_iam_role_policy_attachment" "attach_secret_read_policy" {
+  role       = aws_iam_role.lambda_tf_automation_role.name
+  policy_arn = aws_iam_policy.lambda_secret_read_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "attach_lambda_basic_execution" {
+  role       = aws_iam_role.lambda_tf_automation_role.name
+  policy_arn = data.aws_iam_policy.lambda_basic_execution_role.arn
+}
+
 
 # Lambda 함수 정의
 resource "aws_lambda_function" "tf_automation_lambda" {

--- a/envs/static/modules/tf_automation/variables.tf
+++ b/envs/static/modules/tf_automation/variables.tf
@@ -15,9 +15,18 @@ variable "component" {
 
 variable "lambda_schedules" {
   type = map(object({
-    schedule_expression          = string
-    action                       = string
-    env                          = string
+    schedule_expression = string
+    action              = string
+    env                 = string
   }))
   description = "환경별 Scheduler 설정"
+}
+
+
+variable "asg_config" {
+  type = map(object({
+    min_size     = number
+    desired_size = number
+    max_size     = number
+  }))
 }

--- a/envs/static/variables.tf
+++ b/envs/static/variables.tf
@@ -110,3 +110,17 @@ variable "lambda_schedules" {
     }
   }
 }
+
+variable "asg_config" {
+  description = "key: env, value: asg 인스턴스 크기"
+  type = map(object({
+    min_size     = number
+    desired_size = number
+    max_size     = number
+  }))
+  default = {
+    "dev"   : { "min_size": 1, "desired_size": 1, "max_size": 1 },
+    "shared": { "min_size": 0, "desired_size": 0, "max_size": 0 },
+    "prod"  : { "min_size": 1, "desired_size": 1, "max_size": 2 }
+  }
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
SG 인스턴스 스케일 조정을 위한 변수와 로직을 추가하고, Lambda가 EC2 인스턴스를 제어할 수 있도록 IAM 권한 및 처리 로직을 확장했습니다.
## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- asg_config 변수 및 local.lambda_schedules 정의 추가 
- action이 stop일 경우 ASG 스케일을 0으로 설정
- Lambda IAM Role에 Autoscaling, RDS, SecretsManager, EC2 관련 권한 부여
- Lambda 함수에 EC2 인스턴스 상태 조회 및 start/stop 처리 로직 추가
- Lambda 환경 변수로 ASG 스케일 값 전달 (min/desire/max)
## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
- #52
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->