### PR TITLE
Feat: GCP site to site vpn 연결을 위한 라우팅 테이블 설정 [0%]

### DIFF
--- a/envs/shared/main.tf
+++ b/envs/shared/main.tf
@@ -128,3 +128,8 @@ module "monitoring_instance" {
   listener_rule_priority    = var.monitoring_listener_rule_priority
   host_header_values = [var.monitoring_alias_name]
 }
+
+module "vpn_networking" {
+  source = "./modules/vpn_networking"
+  private_rt = module.network.private_route_table_ids
+}

--- a/envs/shared/modules/vpn_networking/data.tf
+++ b/envs/shared/modules/vpn_networking/data.tf
@@ -1,0 +1,3 @@
+data "aws_vpn_gateway" "this" {
+  id = "vgw-0d337a3c5084bf5d5"
+}

--- a/envs/shared/modules/vpn_networking/main.tf
+++ b/envs/shared/modules/vpn_networking/main.tf
@@ -1,0 +1,5 @@
+resource "aws_vpn_gateway_route_propagation" "this" {
+  for_each = var.private_rt
+  vpn_gateway_id = data.aws_vpn_gateway.this.id 
+  route_table_id = each.value
+}

--- a/envs/shared/modules/vpn_networking/variables.tf
+++ b/envs/shared/modules/vpn_networking/variables.tf
@@ -1,0 +1,4 @@
+variable "private_rt" {
+  description = "vpn과 연결할 private routing table id"
+  type = map(string)
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -36,3 +36,8 @@ output "private_route_table_ids" {
     for az, rt in aws_route_table.private : az => rt.id
   }
 }
+
+output "private_route_table_id_list" {
+  description = "private route table id list"
+  value = values(aws_route_table.private)[*].id
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
GCP와 AWS 간 site-to-site VPN 연결을 위해 필요한 AWS 측 라우팅 테이블 전파 설정했습니다. 

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- GCP VPN Gateway에서 shared 환경의 모든 Private Route Table로의 경로 전파
- Terraform 모듈화 구조 반영: `modules/vpn_networking` 생성
- `envs/shared` 내 VPN 설정 적용

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
- #64 
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
- 실제 VPN 연결 전에 GCP 측 라우터 및 터널 설정이 완료되어야 경로가 정상 동작합니다.
- `aws_vpn_gateway` 리소스는 기존 생성된 VGW ID를 `data`로 참조합니다. 값이 변경될 경우 수정 필요합니다.